### PR TITLE
Install fuse3 rather than outdated fuse, and no longer auto-accept po…

### DIFF
--- a/linux.sh
+++ b/linux.sh
@@ -1,6 +1,6 @@
 echo Downloading Beeper prerequisites, please accept the SuDo request.
 sudo apt upgrade -y
-sudo apt install nano libnss3 libnotify4 libsecret-1-0 fuse -y
+sudo apt install nano libnss3 libnotify4 libsecret-1-0 fuse3
 wget https://download.beeper.com/linux/appImage/x64 -O Beeper.AppImage
 wget https://raw.githubusercontent.com/Naazim-Apps/Beeper-install/main/beeper.desktop
 chmod a+x Beeper.AppImage


### PR DESCRIPTION
…ssibly breaking changes

The current command uninstalled several critical packages on Ubuntu 24.04 LTS because it removed fuse3 and anything that depended on it as fuse3 and fuse conflict.